### PR TITLE
Add description so that the mod can load properly

### DIFF
--- a/furniture/furniture_override.json
+++ b/furniture/furniture_override.json
@@ -50,6 +50,7 @@
     "type": "furniture",
     "id": "f_robotic_arm",
     "name": "robotic arm",
+    "description": "This is a robotic arm.",
     "symbol": "&",
     "bgcolor": "yellow",
     "move_cost_mod": 3,


### PR DESCRIPTION
Description field was missing from one furniture keeping the mod from loading.
I have no idea if you still check on this, but I made a quick fix anyway.